### PR TITLE
Use Services global variable

### DIFF
--- a/src/experiments/calendar/parent/ext-calendar-calendars.js
+++ b/src/experiments/calendar/parent/ext-calendar-calendars.js
@@ -8,7 +8,6 @@ var { ExtensionUtils } = ChromeUtils.import("resource://gre/modules/ExtensionUti
 var { ExtensionAPI, EventManager } = ExtensionCommon;
 var { ExtensionError } = ExtensionUtils;
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { cal } = ChromeUtils.import("resource:///modules/calendar/calUtils.jsm");
 
 this.calendar_calendars = class extends ExtensionAPI {

--- a/src/experiments/calendar/parent/ext-calendar-provider.js
+++ b/src/experiments/calendar/parent/ext-calendar-provider.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { cal } = ChromeUtils.import("resource:///modules/calendar/calUtils.jsm");
 
 var { ExtensionAPI, EventManager } = ExtensionCommon;


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm if the strict_min_version is 102.