### PR TITLE
Add a global reminder (x days before birthday)

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -76,5 +76,13 @@
   "ageCutoffYear2": {
     "message": " ignorieren",
     "description": "Label for the latest birthyear to ignore when doing age calculations, rendered after the editable field."
+  },
+  "daysReminder": {
+    "message": "Erinnerung vor dem Geburtstag in Tagen:",
+    "description": "Label for the reminder."
+  },
+  "BirthdayOf": {
+    "message": "Geburtstag von",
+    "description": "Reminder description"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -76,5 +76,13 @@
   "ageCutoffYear2": {
     "message": " ",
     "description": "Label for the latest birthyear to ignore when doing age calculations, rendered after the editable field."
+  },
+  "daysReminder": {
+    "message": "Reminder before the birthday in days:",
+    "description": "Label for the reminder."
+  },
+  "BirthdayOf": {
+    "message": "Birthday of",
+    "description": "Reminder description"
   }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -66,13 +66,61 @@ const BC = {};
     await Promise.all(existingCalendars.map(c => Mc.calendars.remove(c.id)));
     return existingCalendars.length > 0;
   };
+  
+  // Calculate dates
+  BC.getTimestamp = function(year, month, day, hours, minutes, seconds) {
+    const mm = String(month).padStart(2, '0');
+    const dd = String(day).padStart(2, '0');
+    const hh = String(hours).padStart(2, '0');
+    const min = String(minutes).padStart(2, '0');
+    const sec = String(seconds).padStart(2, '0');
+    const bdate = year + '-' + mm + '-' + dd + 'T' + hh + ':' + min + ':' + sec;
+    return Math.floor(new Date(bdate).getTime());
+  }
+  BC.getDiffDays = function(TS_Midnight, TS_Now, days, delaySecs) {
+    let diffDelay = TS_Now - (days*24*60*60*1000);
+    let diff = diffDelay - TS_Midnight + (delaySecs * 1000);
+
+    let daysDiff = Math.floor(diff/1000/60/60/24);
+    diff -= daysDiff*1000*60*60*24;
+    let hoursDiff = Math.floor(diff/1000/60/60);
+    diff -= hoursDiff*1000*60*60;
+    let minutesDiff = Math.floor(diff/1000/60);
+    diff -= minutesDiff*1000*60;
+    let secondsDiff = Math.floor(diff/1000);
+    /*
+    console.log('Diff = ' +
+      daysDiff + ' day/s ' +
+      hoursDiff + ' hour/s ' +
+      minutesDiff + ' minute/s ' +
+      secondsDiff + ' second/s ');
+    */
+
+    diff = "PT";
+    if (daysDiff < 0){
+      daysDiff = Math.abs(daysDiff);
+      hoursDiff = Math.abs(23 - hoursDiff);
+      minutesDiff = Math.abs(59 - minutesDiff);
+      secondsDiff = Math.abs(59 - secondsDiff);
+      if (daysDiff > 1) {
+        daysDiff -= 1;
+        diff = "-P" + daysDiff +"DT";
+      } else {
+        diff = "-PT";
+      }
+    }
+    diff += hoursDiff + "H" + minutesDiff + 'M'+ secondsDiff + 'S';
+    
+    return diff;
+  }
 
 
   // Settings
   BC.getGlobalSettings = async function() {
     return await Msl.get({
       yearsToDisplayAgeFor: 2,
-      ageCutoffYear: null
+      ageCutoffYear: null,
+      daysRemind: 0
     });
   };
 

--- a/src/options.js
+++ b/src/options.js
@@ -5,6 +5,8 @@
 // enforcing a concrete birth year if no actual year is known.
 const defaultAgeCutoffYear = 1604;
 
+const defaultReminder = 0;
+
 let abList; // div containing the list of address books
 
 async function refreshAbList() {
@@ -42,7 +44,7 @@ addEventListener('load', () => (async () => {
     const years = settings.yearsToDisplayAgeFor;
     const placeholders = [
       currentYear - Math.max(years - 1, 0),
-      currentYear + years - 1
+      currentYear + years - 1,
     ];
     const rangeText = Mi.getMessage("ageCalculationRange"
         + (years > 1 ? "" : years == 1 ? "CurrentYear" : "None"), placeholders);
@@ -101,6 +103,34 @@ addEventListener('load', () => (async () => {
   ageCutoffYear.addEventListener("change", ageCutoffUpdate);
   ageCutoffCheckbox.addEventListener("click", ageCutoffUpdate);
 
+  const daysReminderLabel = document.createElement("label");
+  const reminderCheckbox = document.createElement("input");
+  reminderCheckbox.type = "checkbox";
+  reminderCheckbox.checked = !!settings.daysRemind;
+  daysReminderLabel.appendChild(reminderCheckbox);
+  daysReminderLabel.appendChild(document.createTextNode(Mi.getMessage(
+      "daysReminder")));
+  const daysRemind = document.createElement("input");
+  daysRemind.type = "number";
+  daysRemind.min = 0;
+  daysRemind.max = 21;
+  daysRemind.value = settings.daysRemind ?? defaultReminder;
+  daysRemind.disabled = !settings.daysRemind;
+  daysReminderLabel.appendChild(daysRemind);
+  document.body.appendChild(daysReminderLabel);
+  const daysRemindUpdate = () => (async () => {
+    if (reminderCheckbox.checked) {
+      settings.daysRemind = daysRemind.value;
+      daysRemind.disabled = false;
+    } else {
+      settings.daysRemind = NaN;
+      daysRemind.disabled = true;
+    }
+    await BC.setGlobalSettings(settings);
+  })().catch(console.error);
+  daysRemind.addEventListener("change", daysRemindUpdate);
+  reminderCheckbox.addEventListener("click", daysRemindUpdate);
+
   document.body.appendChild(document.createElement("hr"));
 
   const abListLabel = document.createElement("p");
@@ -116,4 +146,3 @@ addEventListener('load', () => (async () => {
   Mab.onDeleted.addListener(refreshAbList);
   await refreshAbList();
 })().catch(console.error), {once: true});
-


### PR DESCRIPTION
Hi,
I have added a quick & dirty reminder to your nice add-on (potential fix for #3). You can optionally enable reminders 0 - 21 days before the birthday (globally for all selected address books).

I call it "quick & dirty" because there is a small drawback in the implementation: Since the birthday calendar is re-created each time Thunderbird is started, there is no way of knowing if a (missed) reminder has already been displayed or not. So I cannot define a specific time of the day as reminder, because no reminder would be displayed, if you start TB after that time. For this reason I have chosen the _current time_ as the reminder.
The consequence of this workaround is that you'll get a reminder several times a day when TB is (re)started!

Also, you cannot snooze the reminder because the birthday calendar is write-protected.

Let me know what you think!