### PR TITLE
Convert italian translation to utf8

### DIFF
--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -22,7 +22,7 @@
     "description": "Label above the list of address books in the preferences"
   },
   "ageCalculationRangeSetting1": {
-    "message": "Calcolare l'intervallo di et‡ entro cui operare:",
+    "message": "Calcolare l'intervallo di et√† entro cui operare:",
     "description": "Label for the setting controlling the range to generate age information for, rendered before the editable field.",
     "placeholders": {
       "range": {
@@ -66,7 +66,7 @@
     }
   },
   "ageCalculationRangeNone": {
-    "message": "nessun calcolodi et‡",
+    "message": "nessun calcolodi et√†",
     "description": "Text representing the range in which age calculation takes place, if age calculation is disabled"
   },
   "ageCutoffYear1": {


### PR DESCRIPTION
I couldn't install the extension after building the add-on from the master branch. After checking in the Thunderbird developer tools/debugger, it pointed me to issues loading the new Italian translations:
<img width="1583" height="48" alt="grafik" src="https://github.com/user-attachments/assets/3caad398-9328-44db-a94b-a0fca825dda4" />

After converting the new translation to UTF-8, I was able to install the add-on.