### PR TITLE
add remainders Issue3

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -69,12 +69,16 @@ const BC = {};
 
 
   // Settings
-  BC.getGlobalSettings = async function() {
+BC.getGlobalSettings = async function() {
     return await Msl.get({
-      yearsToDisplayAgeFor: 2,
-      ageCutoffYear: null
+        yearsToDisplayAgeFor: 2,
+        ageCutoffYear: null,
+        reminderMinus1Week: false,
+        reminderMinus6Hours: false,
+        reminderPlus7Hours: false,
+        reminderPlus18Hours: false
     });
-  };
+};
 
   BC.setGlobalSettings = async function(settings) {
     await Msl.set(settings);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
     "gecko": {
       "id": "birthdaycalendar@rsjtdrjgfuzkfg.com",
       "strict_min_version": "128.0",
-      "strict_max_version": "140.*"
+      "strict_max_version": "141.*"
     }
   },
   "name": "__MSG_extensionName__",

--- a/src/options.js
+++ b/src/options.js
@@ -109,6 +109,63 @@ addEventListener('load', () => (async () => {
 
   abList = document.createElement("div");
   document.body.appendChild(abList);
+  
+  // Reminder section
+  // Add a separator line and label for reminder selection
+  document.body.appendChild(document.createElement("hr"));
+  const remListLabel = document.createElement("p");
+  remListLabel.textContent = Mi.getMessage("ReminderSelection") || "Reminder selection:";
+  document.body.appendChild(remListLabel);
+  
+  // Container for the reminder checkboxes
+  const remList = document.createElement("div");
+  document.body.appendChild(remList);
+  
+  // Define your three distinct reminder options with keys and labels
+  const reminderOptions = [
+    { key: "reminderMinus1Week",   label: "Reminder at 7:00 AM, 1 week before" },
+    { key: "reminderMinus6Hours",  label: "Reminder at 6:00 PM the day before (−6 hours)" },
+    { key: "reminderPlus7Hours",   label: "Reminder at 7:00 AM on the day (+7 hours)" },
+    { key: "reminderPlus18Hours",  label: "Reminder at 6:00 PM on the day (+18 hours)" },
+  ]; // if this list is changed you need to change:
+  //         - BC.getGlobalSettings = async function()  in common.js 
+  //         - buildRemindersAlarms in provider.js
+  
+  for (const option of reminderOptions) {
+    const label = document.createElement("label");
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+  
+    // Initialize state from settings, default false
+    checkbox.checked = !!settings[option.key];
+  
+    // Store setting key to use in event handler
+    checkbox.dataset.settingKey = option.key;
+  
+    // Accessibility: link label with checkbox
+    const checkboxId = `checkbox_${option.key}`;
+    checkbox.id = checkboxId;
+    label.htmlFor = checkboxId;
+  
+    label.appendChild(checkbox);
+    label.appendChild(document.createTextNode(" " + option.label));
+    remList.appendChild(label);
+  
+    // Save setting on checkbox toggle
+	checkbox.addEventListener("click", async () => {
+      try {
+        settings[checkbox.dataset.settingKey] = checkbox.checked;
+        await BC.setGlobalSettings(settings);
+        //console.log("Settings saved:", settings);
+        // we need to sync the calendars
+        await Mc.calendars.synchronize();
+      } catch (e) {
+        console.error("Error saving settings:", e);
+      }
+    });
+  }
+
+  // end of Reminder section
 
   Mc.calendars.onRemoved.addListener(refreshAbList);
   Mc.calendars.onCreated.addListener(refreshAbList);


### PR DESCRIPTION
Fixes #3

with the concept listed in the comment:
https://github.com/rsjtdrjgfuzkfg/thunderbird-birthdaycalendar/issues/3#issuecomment-3121813348



    Reminder at 7:00 AM, 1 week before
    Gives me time to think about a birthday gift.

    Reminder at 6:00 PM the day before (−6 hours)
    Gives me time to consider why I am invited to a party today…

    Reminder at 7:00 AM on the day (+7 hours)
    I need to congratulate the contact if I see them in person today.

    Reminder at 6:00 PM on the day (+18 hours)
    Have I already congratulated them? If not, this reminds me to maybe call.


PS: I'm sorry but I did not check the language messages. The changes work with my calendar but I did not test all special cases with pop up messages.