### PR TITLE
Respect vCard dates with extended date format

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -60,9 +60,11 @@ Mc.provider.onSync.addListener(async (cal) => {
           // per RFC 6350 and assuming the type is DATE or DATE-TIME, there are
           // two relevant date formats (there are others that do not include
           // both day and month, but we're not interested in them):
-          // YYYYMMDD   (ISO 8601:2004 4.1.2.2 basic), 
-          // YYYY-MM-DD (ISO 8601:2004 4.1.2.2 extended),
-          // --MMDD     (ISO 8601:2000 5.2.1.3 d basic), 
+          // YYYYMMDD   (ISO 8601:2004 4.1.2.2 basic)
+          // --MMDD     (ISO 8601:2000 5.2.1.3 d basic)
+          // older versions of vCard also permit other formats via RFC 2425,
+          // which has less stringent requirements. We thus also support:
+          // YYYY-MM-DD (ISO 8601:2004 4.1.2.2 extended)
           // --MM-DD    (ISO 8601:2000 5.2.1.3 d extended)
           + "(--|[0-9]{4})-?([0-9]{2})-?([0-9]{2})"
           // which can be optionally followed by a time separated by 'T'

--- a/src/provider.js
+++ b/src/provider.js
@@ -60,9 +60,11 @@ Mc.provider.onSync.addListener(async (cal) => {
           // per RFC 6350 and assuming the type is DATE or DATE-TIME, there are
           // two relevant date formats (there are others that do not include
           // both day and month, but we're not interested in them):
-          // YYYYMMDD (ISO 8601:2004 4.1.2.2 basic)
-          // --MMDD   (ISO 8601:2000 5.2.1.3 d basic)
-          + "(--|[0-9]{4})([0-9]{2})([0-9]{2})"
+          // YYYYMMDD   (ISO 8601:2004 4.1.2.2 basic), 
+          // YYYY-MM-DD (ISO 8601:2004 4.1.2.2 extended),
+          // --MMDD     (ISO 8601:2000 5.2.1.3 d basic), 
+          // --MM-DD    (ISO 8601:2000 5.2.1.3 d extended)
+          + "(--|[0-9]{4})-?([0-9]{2})-?([0-9]{2})"
           // which can be optionally followed by a time separated by 'T'
           + "(?:T[0-9Z-]*)?[\r\n]");
       if (birthdayMatch) {


### PR DESCRIPTION
Hi! 
Some time ago I noticed that this (otherwise wonderful) extension doesn't seem to handle VCARD content that uses the extended date format for birthdays.
I don't know how widely used this is, but the [sabre/dav](https://github.com/sabre-io/dav) library for example seems to do this.

Example vCard exported from Thunderbird:
```
BEGIN:VCARD
VERSION:3.0
PRODID:-//Sabre//Sabre VObject 4.5.7//EN
N:Year;Test With;;;
FN:Test With Year
BDAY;VALUE=DATE:1970-01-01
UID:10799bf4-24a2-429a-92c7-550d42893cd2
END:VCARD
```

This PR proposes to change the regular expression used for parsing the date (including dashes in the reduced precision format) so that birthdays like in the vCard above can be recognized correctly.